### PR TITLE
Fix version detection logic for game versions 2024.6 and up

### DIFF
--- a/Multiscreen/Multiscreen.cs
+++ b/Multiscreen/Multiscreen.cs
@@ -22,16 +22,16 @@ public static class MultiscreenLoader
         string coreVer = CORE_NAME;
 
         WriteLog($"Game Version: {Application.version}");
-        switch (Application.version.Substring(0,6))
+        string shortVersion = Application.version.Substring(0, 6);
+        if (Version.TryParse(shortVersion, out Version parsedVersion) && parsedVersion >= new Version("2024.6"))
         {
-            case "2024.6":
-                coreVer += "Beta";
-                break;
-
-            default:
-                coreVer += "Main";
-                break;
+            coreVer += "Beta";
         }
+        else
+        {
+            coreVer += "Main";
+        }
+
 
         WriteLog($"Selected Core Version: {coreVer}");
 


### PR DESCRIPTION
This PR updates the version detection logic in Multiscreen.cs to ensure that game versions 2024.6 and higher correctly select the Beta assembly, instead of falling back to the outdated Main branch logic. This resolves an issue where the mod loaded the wrong core logic under newer game versions (e.g., 2025.1), leading to broken display focus and input behavior.
No functional changes are introduced for both builds.