### PR TITLE
Fix: ReflectionTypeLoadException crash on Railroader 2025.1.0b+

### DIFF
--- a/Multiscreen.Core/Patches/Misc/GameInputPatch.cs
+++ b/Multiscreen.Core/Patches/Misc/GameInputPatch.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using UnityEngine;
 using UI;
 using UI.Common;
@@ -18,7 +18,23 @@ public class GameInputPatch
         //Multidisplay aware mousePosition
         Vector3 vector = Display.RelativeMouseAt(Input.mousePosition);
 
-        bool bounds = 0f <= vector.x && 0f <= vector.y && Screen.width >= vector.x && Screen.height >= vector.y;
+        //Use the correct display dimensions based on which display the mouse is on
+        int displayIndex = (int)vector.z;
+        float displayWidth;
+        float displayHeight;
+
+        if (displayIndex > 0 && displayIndex < Display.displays.Length)
+        {
+            displayWidth = Display.displays[displayIndex].renderingWidth;
+            displayHeight = Display.displays[displayIndex].renderingHeight;
+        }
+        else
+        {
+            displayWidth = Screen.width;
+            displayHeight = Screen.height;
+        }
+
+        bool bounds = 0f <= vector.x && 0f <= vector.y && displayWidth >= vector.x && displayHeight >= vector.y;
         Window hit = WindowManager.Shared.HitTest(vector);
 
         //Multiscreen.Log($"IsMouseOverGameWindow({window?.name}): __result: {__result}\r\n\tBounds:{bounds}\r\n\thit: {hit?.name} :: {hit == window}");

--- a/Multiscreen.Core/Patches/Windows/GenericWindowInstancePatch.cs
+++ b/Multiscreen.Core/Patches/Windows/GenericWindowInstancePatch.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using Multiscreen.Util;
 using System;
 using System.Collections.Generic;
@@ -72,8 +72,9 @@ public static class GenericWindowInstanceHelper
     {
 
         //Manual additions due to inconsistency in game code
-        var manualTypes = AppDomain.CurrentDomain.GetAssemblies()
-                    .SelectMany(t => t.GetTypes())
+        //Using PatchUtils.GetAllTypesSafe() instead of raw GetTypes() to handle
+        //ReflectionTypeLoadException after Unity engine updates
+        var manualTypes = PatchUtils.GetAllTypesSafe()
                     .Where(t => MANUAL_TYPES.Contains(t.Name));
 
         var windowTypes = PatchUtils.ScanForInterface("IProgrammaticWindow")
@@ -82,49 +83,48 @@ public static class GenericWindowInstanceHelper
             .Union(manualTypes)
             .Distinct();
 
-        //if(manualTypes != null) 
-        //{
-        //    Logger.LogDebug(() =>
-        //    {
-        //        StringBuilder sb = new();
-
-        //        sb.AppendLine($"GetWindowTypesToPatch Found {manualTypes.Count()} methods to patch");
-
-        //        foreach (var method in manualTypes)
-        //            sb.AppendLine($"GetWindowTypesToPatch: {method.Name}.{method.Name}");
-
-        //        return sb.ToString();
-        //    });
-        //    windowTypes = windowTypes.Union(manualTypes).Distinct();
-        //}
-
         return windowTypes.Where(HasPropertyToPatch);
     }
 
     private static bool HasPropertyToPatch(Type type)
     {
-        var properties = type.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        try
+        {
+            var properties = type.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
 
-        var hasShared = properties.Any(p => p.Name.Equals("shared", StringComparison.OrdinalIgnoreCase));
-        var hasInstance = properties.Any(p => p.Name.Equals("instance", StringComparison.OrdinalIgnoreCase));
+            var hasShared = properties.Any(p => p.Name.Equals("shared", StringComparison.OrdinalIgnoreCase));
+            var hasInstance = properties.Any(p => p.Name.Equals("instance", StringComparison.OrdinalIgnoreCase));
 
-        Logger.LogDebug($"HasPropertyToPatch({type.Name}) {hasShared || hasInstance}");
-        return hasShared || hasInstance;
+            Logger.LogDebug($"HasPropertyToPatch({type.Name}) {hasShared || hasInstance}");
+            return hasShared || hasInstance;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug($"Error checking properties on type {type.Name}: {ex.Message}");
+            return false;
+        }
     }
 
     public static IEnumerable<MethodBase> GetMethodsToPatch(Type type)
     {
         var methods = new List<MethodBase>();
 
-        var properties = type.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        try
+        {
+            var properties = type.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
 
-        var sharedProp = properties.FirstOrDefault(p => p.Name.Equals("shared", StringComparison.OrdinalIgnoreCase));
-        if (sharedProp?.GetGetMethod(true) != null)  // true to get non-public accessor
-            methods.Add(sharedProp.GetGetMethod(true));
+            var sharedProp = properties.FirstOrDefault(p => p.Name.Equals("shared", StringComparison.OrdinalIgnoreCase));
+            if (sharedProp?.GetGetMethod(true) != null)  // true to get non-public accessor
+                methods.Add(sharedProp.GetGetMethod(true));
 
-        var instanceProp = properties.FirstOrDefault(p => p.Name.Equals("instance", StringComparison.OrdinalIgnoreCase));
-        if (instanceProp?.GetGetMethod(true) != null)  // true to get non-public accessor
-            methods.Add(instanceProp.GetGetMethod(true));
+            var instanceProp = properties.FirstOrDefault(p => p.Name.Equals("instance", StringComparison.OrdinalIgnoreCase));
+            if (instanceProp?.GetGetMethod(true) != null)  // true to get non-public accessor
+                methods.Add(instanceProp.GetGetMethod(true));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug($"Error getting methods to patch on type {type.Name}: {ex.Message}");
+        }
 
         return methods; 
     }

--- a/Multiscreen.Core/Util/PatchUtils.cs
+++ b/Multiscreen.Core/Util/PatchUtils.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -8,16 +9,46 @@ namespace Multiscreen.Util;
 
 public static class PatchUtils
 {
+    /// <summary>
+    /// Safely gets types from an assembly, handling ReflectionTypeLoadException
+    /// that occurs when some types reference missing dependencies (common after
+    /// Unity engine updates).
+    /// </summary>
+    public static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            Logger.LogDebug($"ReflectionTypeLoadException in assembly {assembly.FullName}, returning {ex.Types.Count(t => t != null)} of {ex.Types.Length} types");
+            return ex.Types.Where(t => t != null);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug($"Exception loading types from assembly {assembly.FullName}: {ex.Message}");
+            return Enumerable.Empty<Type>();
+        }
+    }
+
+    /// <summary>
+    /// Gets all types from all loaded assemblies, safely handling load failures.
+    /// </summary>
+    public static IEnumerable<Type> GetAllTypesSafe()
+    {
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .SelectMany(a => SafeGetTypes(a));
+    }
+
     public static Type[] ScanForInterface(string interfaceName)
     {
-        var interfaceType = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(a => a.GetTypes())
+        var interfaceType = GetAllTypesSafe()
             .FirstOrDefault(t => t.Name == interfaceName);
 
         if (interfaceType != null)
         {
-            var types = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(s => s.GetTypes())
+            var types = GetAllTypesSafe()
                 .Where(p => !p.IsInterface && interfaceType.IsAssignableFrom(p))
                 .ToArray();
 
@@ -39,15 +70,24 @@ public static class PatchUtils
 
     public static Type[] ScanForRequireComponent(Type component)
     {
-        var types = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(s => s.GetTypes())
+        var types = GetAllTypesSafe()
             .Where(type =>
-                type.GetCustomAttributes<RequireComponent>()
-                    .Any(attr =>
-                        (attr.m_Type0 != null && attr.m_Type0 == component) ||
-                        (attr.m_Type1 != null && attr.m_Type1 == component) ||
-                        (attr.m_Type2 != null && attr.m_Type2 == component)
-                    ))
+            {
+                try
+                {
+                    return type.GetCustomAttributes<RequireComponent>()
+                        .Any(attr =>
+                            (attr.m_Type0 != null && attr.m_Type0 == component) ||
+                            (attr.m_Type1 != null && attr.m_Type1 == component) ||
+                            (attr.m_Type2 != null && attr.m_Type2 == component)
+                        );
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug($"Error checking RequireComponent on type {type.FullName}: {ex.Message}");
+                    return false;
+                }
+            })
             .ToArray();
 
         Logger.LogDebug(() =>


### PR DESCRIPTION
Problem
Multiscreen 1.6.3.0 fails to load on Railroader 2025.1.0 (build 20238526) with the following error:
Failed to load: Patching exception in method static System.Collections.Generic.IEnumerable`1<System.Reflection.MethodBase> Multiscreen.Patches.Windows.GenericWindowInstancePatch::TargetMethods()
The issue was introduced by the 2025.1.0b hotfix, which updated the Unity engine to 2022.3.62f2. This engine update caused some loaded assemblies to contain types with unresolvable dependencies. When Assembly.GetTypes() encounters these types, it throws a ReflectionTypeLoadException, which was unhandled in the mod's assembly scanning code.
The game version and mod version appear to match correctly, and all target types (IProgrammaticWindow, IBuilderWindow, Window, EngineRosterPanel, PlacerWindow) are still present and unchanged in the game assemblies. The failure is in the scanning process itself, not in missing targets.
Reproduced on two separate machines running identical game and mod versions.
Changes
PatchUtils.cs

Added SafeGetTypes(Assembly) helper method that wraps Assembly.GetTypes() in a try-catch for ReflectionTypeLoadException, returning only successfully loaded types instead of crashing
Added GetAllTypesSafe() convenience method for scanning all loaded assemblies using the safe getter
Updated ScanForInterface() to use GetAllTypesSafe() instead of raw GetTypes()
Updated ScanForRequireComponent() to use GetAllTypesSafe() and added a try-catch around attribute resolution
Added debug logging when partial type loads occur

GenericWindowInstancePatch.cs

Updated GetWindowTypesToPatch() to use PatchUtils.GetAllTypesSafe() instead of raw GetTypes() for the manual type lookup
Added try-catch in HasPropertyToPatch() to handle property reflection failures
Added try-catch in GetMethodsToPatch() to handle method resolution failures

Testing
Tested on Railroader 2025.1.0 (build 20238526) with Unity Mod Manager (doorstop method) and 0Harmony 2.3.6.0. Mod loads and functions correctly after the fix. Verified on two separate machines.